### PR TITLE
Allow BatchSpanProcessor to send early when a full batch is ready

### DIFF
--- a/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
@@ -235,7 +235,7 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
     }
     this._isFlushInProgress = true;
     this._clearTimer();
-    
+
     const spans = this._finishedSpans.splice(0, this._maxExportBatchSize);
     this._export(spans)
       .then(() => {

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/SimpleSpanProcessor.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/SimpleSpanProcessor.test.ts
@@ -200,7 +200,7 @@ describe('SimpleSpanProcessor', () => {
     });
 
     it('should await doExport() and delete from _unresolvedExports', async () => {
-      const testExporterWithDelay = new TestExporterWithDelay();
+      const testExporterWithDelay = new TestExporterWithDelay(1);
       const processor = new SimpleSpanProcessor(testExporterWithDelay);
 
       const providerWithAsyncResource = new BasicTracerProvider({

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/TestExporterWithDelay.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/TestExporterWithDelay.ts
@@ -22,7 +22,7 @@ import { InMemorySpanExporter, ReadableSpan } from '../../../src';
  */
 export class TestExporterWithDelay extends InMemorySpanExporter {
   private _exporterCreatedSpans: ReadableSpan[] = [];
-  private _delayMs: number; 
+  private _delayMs: number;
 
   constructor(delayMs: number) {
     super();
@@ -33,7 +33,7 @@ export class TestExporterWithDelay extends InMemorySpanExporter {
     spans: ReadableSpan[],
     resultCallback: (result: ExportResult) => void
   ): void {
-    setTimeout(() => super.export(spans,resultCallback), this._delayMs);
+    setTimeout(() => super.export(spans, resultCallback), this._delayMs);
   }
 
   override shutdown(): Promise<void> {

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/TestExporterWithDelay.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/TestExporterWithDelay.ts
@@ -22,16 +22,18 @@ import { InMemorySpanExporter, ReadableSpan } from '../../../src';
  */
 export class TestExporterWithDelay extends InMemorySpanExporter {
   private _exporterCreatedSpans: ReadableSpan[] = [];
+  private _delayMs: number; 
 
-  constructor() {
+  constructor(delayMs: number) {
     super();
+    this._delayMs = delayMs;
   }
 
   override export(
     spans: ReadableSpan[],
     resultCallback: (result: ExportResult) => void
   ): void {
-    super.export(spans, () => setTimeout(resultCallback, 1));
+    setTimeout(() => super.export(spans,resultCallback), this._delayMs);
   }
 
   override shutdown(): Promise<void> {


### PR DESCRIPTION
The `BatchSpanProcessor` waits `scheduledDelayMillis` (5000 by default) since the arrival of the first span, or since the last export before exporting. It never exports more than one batch of `maxExportBatchSize` (512 by default). If there's more than 512 spans produced per 5000 seconds the surplus starts building up in the queue, until it overflows and starts dropping spans. Which is observable though these logs: `Dropped 2576 spans because maxQueueSize reached`

In comparision Java's `BatchSpanProcessor` also uses a configured delay and batch size, but will send the batch as soon as sufficient number of spans is enqueued (https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java#L244). Therefore the delay doesn't limit the maximum throughput.

This PR implements similar logic in JS's BatchSpanProcessor.